### PR TITLE
Feature/linecap

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ You can also customize the circle with following properties:
 | `circleSize`  | The size of the circle (default: 300)  |
 | `strokeWidth`  | The thickness of the stroke (default: 24)  |
 | `strokeColor`  | The color of the stroke (default: "#fc245c")  |
+| `linecap` | The shape of the stroke's endcaps. Use "butt", "round" or "square" (default: "round") |
 | `topColor`  | Top Gradient Color  |
 | `bottomColor`  | Bottom Gradient Color  |
 | `hasCounter`  | Set it to `true`, will show a countdown label  (default: null)  |
@@ -95,6 +96,7 @@ You can also customize the circle with following properties:
 loadingCircle = new Circle
 	circleWidth: 200
 	strokeWidth: 30
+	linecap: "round"
 
 	topColor: "#ff150f"
 	bottomColor: "#ff23bd"

--- a/circleModule.coffee
+++ b/circleModule.coffee
@@ -5,6 +5,7 @@ class exports.Circle extends Layer
 
 		@options.circleSize ?= 300
 		@options.strokeWidth ?= 24
+		@options.linecap ?= "round"
 
 		@options.strokeColor ?= "#fc245c"
 		@options.topColor ?= null
@@ -77,7 +78,7 @@ class exports.Circle extends Layer
 				</defs>
 				<circle id='#{@circleID}'
 						fill='none'
-						stroke-linecap='round'
+						stroke-linecap='#{@options.linecap}'
 						stroke-width      = '#{@options.strokeWidth}'
 						stroke-dasharray  = '#{@.pathLength}'
 						stroke-dashoffset = '0'


### PR DESCRIPTION
Adds the option to customize the circle's linecap (round, square, butt) from the constructor. Nice bonus: you can use the butt linecap and set the stroke width very high for animated pie charts.