### PR TITLE
Name and reorder proxy layers.

### DIFF
--- a/circleModule.coffee
+++ b/circleModule.coffee
@@ -95,6 +95,9 @@ class exports.Circle extends Layer
 
 		@proxy = new Layer
 			opacity: 0
+			name: "circuleModuleProxy"
+			
+		@proxy.sendToBack()
 
 		@proxy.on Events.AnimationEnd, (animation, layer) ->
 			self.onFinished()


### PR DESCRIPTION
Proxy layers tend to accumulate over time as the module is used. This change identifies the proxy layers as such and keeps them at the bottom of the stack.

I don't really understand what the proxy layers do, so double-check that I haven't impacted any functionality. In my own use there seem to be no ill effects.